### PR TITLE
Changed the 'is' keyword to '==' in three instances

### DIFF
--- a/cities/Dresden.py
+++ b/cities/Dresden.py
@@ -49,13 +49,13 @@ def parse_html(html):
 
             count = raw_lot_data[1].text
             count = count.strip()
-            if count is "":
+            if count == "":
                 count = 0
             count = int(count)
 
             free = raw_lot_data[2].text
             free = free.strip()
-            if free is "":
+            if free == "":
                 free = 0
             free = int(free)
 

--- a/server.py
+++ b/server.py
@@ -9,7 +9,7 @@ from logging.handlers import RotatingFileHandler
 
 app = Flask(__name__)
 
-if os.getenv("env") is not "development":
+if not (os.getenv("env") == "development"):
     try:
         config = configparser.ConfigParser()
         config.read("config.ini")


### PR DESCRIPTION
You should change the 'is' keyword in these instances, as 'is' checks strings for identity, not equality of content. '==' is to be used in these tree occasions.