### PR TITLE
select bs4 version to 4.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4
+beautifulsoup4==4.5.3
 Flask
 requests
 feedparser


### PR DESCRIPTION
hard select beautifulsoup 4.5.3 since Hamburg breaks with 4.6.0. This is just a hot fix and needs to be examined further (best with compatibility to a newer beautifulsoup version).