### PR TITLE
Add Basel data

### DIFF
--- a/park_api/cities/Basel.geojson
+++ b/park_api/cities/Basel.geojson
@@ -29,6 +29,7 @@
     },
     "properties": {
       "name": "Parkhaus Bad. Bahnhof",
+      "address": "Schwarzwaldstrasse 160",
       "total": 300, 
       "total_by_weekday": {
         "Saturday": 750,
@@ -43,6 +44,7 @@
     },
     "properties": {
       "name": "Parkhaus Messe",
+      "address": "Riehenstrasse 101",
       "total": 752
     }
   }, {
@@ -53,6 +55,7 @@
     },
     "properties": {
       "name": "Parkhaus Europe",
+      "address": "Hammerstrasse 68",
       "total": 120
     }
   }, {
@@ -63,6 +66,7 @@
     },
     "properties": {
       "name": "Parkhaus Rebgasse",
+      "address": "Rebgasse 20",
       "total": 250
     }
   }, {
@@ -73,6 +77,7 @@
     },
     "properties": {
       "name": "Parkhaus Claramatte",
+      "address": "Klingentalstrasse 25",
       "total": 100,
       "total_by_weekday": {
         "Saturday": 170,
@@ -87,6 +92,7 @@
     },
     "properties": {
       "name": "Parkhaus Clarahuus",
+      "address": "Webergasse 34",
       "total": 52
     }
   }, {
@@ -97,6 +103,7 @@
     },
     "properties": {
       "name": "Parkhaus Elisabethen",
+      "address": "Steinentorberg 5",
       "total": 840
     }
   }, {
@@ -107,6 +114,7 @@
     },
     "properties": {
       "name": "Parkhaus Steinen",
+      "address": "Steinenschanze 5",
       "total": 526
     }
   }, {
@@ -117,6 +125,7 @@
     },
     "properties": {
       "name": "Parkhaus City-USB",
+      "address": "Schanzenstrasse 48",
       "total": 1114
     }
   }, {
@@ -127,6 +136,7 @@
     },
     "properties": {
       "name": "Parkhaus Storchen",
+      "address": "Fischmarkt 10",
       "total": 142
     }
   }, {
@@ -137,6 +147,7 @@
     },
     "properties": {
       "name": "Parkhaus Post Basel",
+      "address": "Gartenstrasse 143",
       "total": 72
     }
   }, {
@@ -147,6 +158,7 @@
     },
     "properties": {
       "name": "Parkhaus Centralbahnparking",
+      "address": "Gartenstrasse 150",
       "total": 286
     }
   }, {
@@ -157,6 +169,7 @@
     },
     "properties": {
       "name": "Parkhaus Aeschen",
+      "address": "Aeschengraben 9",
       "total": 97
     }
   }, {
@@ -167,6 +180,7 @@
     },
     "properties": {
       "name": "Parkhaus Anfos",
+      "address": "Henric Petri-Strasse 21",
       "total": 162
     }
   }, {
@@ -177,6 +191,7 @@
     },
     "properties": {
       "name": "Parkhaus Bahnhof S&uuml;d",
+      "address": "Güterstrasse 115",
       "total": 100
     }
   }]

--- a/park_api/cities/Basel.geojson
+++ b/park_api/cities/Basel.geojson
@@ -1,0 +1,175 @@
+{
+  "type": "FeatureCollection",
+  "features": [{
+      "type": "Feature",
+      "geometry": {
+          "type": "Point",
+          "coordinates": [
+              7.5885761,
+              47.5595986
+          ]
+      },
+      "properties": {
+          "name": "Basel",
+          "type": "city",
+          "url": "https://opendata.swiss/de/dataset/parkleitsystem-basel-rss-feed",
+          "source": "http://www.parkleitsystem-basel.ch/status.php",
+	  "active_support": true,
+          "attribution":{
+            "contributor":"Immobilien Basel-Stadt",
+            "url":"http://www.parkleitsystem-basel.ch/impressum.php",
+            "license":"Creative-Commons-Null-Lizenz (CC-0)"
+          }
+      }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.6089067, 47.5651794]
+    },
+    "properties": {
+      "name": "Parkhaus Bad. Bahnhof",
+      "total": 300 
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5854413, 47.5504138]
+    },
+    "properties": {
+      "name": "Parkhaus Messe",
+      "total": 752
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5967098, 47.5630411]
+    },
+    "properties": {
+      "name": "Parkhaus Europe",
+      "total": 120
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.594263, 47.5607142]
+    },
+    "properties": {
+      "name": "Parkhaus Rebgasse",
+      "total": 250
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5946604, 47.5639644]
+    },
+    "properties": {
+      "name": "Parkhaus Claramatte",
+      "total": 100
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5917937, 47.5622725]
+    },
+    "properties": {
+      "name": "Parkhaus Clarahuus",
+      "total": 52
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5874932, 47.5506254]
+    },
+    "properties": {
+      "name": "Parkhaus Elisabethen",
+      "total": 840
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5858936, 47.5524554]
+    },
+    "properties": {
+      "name": "Parkhaus Steinen",
+      "total": 526
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5824076, 47.561101]
+    },
+    "properties": {
+      "name": "Parkhaus City-USB",
+      "total": 1114
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.58658, 47.5592347]
+    },
+    "properties": {
+      "name": "Parkhaus Storchen",
+      "total": 142
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5929374, 47.5468617]
+    },
+    "properties": {
+      "name": "Parkhaus Post Basel",
+      "total": 72
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5922975, 47.547299]
+    },
+    "properties": {
+      "name": "Parkhaus Centralbahnparking",
+      "total": 286
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5943046, 47.5504299]
+    },
+    "properties": {
+      "name": "Parkhaus Aeschen",
+      "total": 97
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.593512, 47.5515968]
+    },
+    "properties": {
+      "name": "Parkhaus Anfos",
+      "total": 162
+    }
+  }, {
+    "type": "Feature",
+    "geometry": {
+      "type": "Point",
+      "coordinates": [7.5884556, 47.5458851]
+    },
+    "properties": {
+      "name": "Parkhaus Bahnhof S&uuml;d",
+      "total": 100
+    }
+  }]
+}

--- a/park_api/cities/Basel.geojson
+++ b/park_api/cities/Basel.geojson
@@ -12,8 +12,8 @@
       "properties": {
           "name": "Basel",
           "type": "city",
-          "url": "https://opendata.swiss/de/dataset/parkleitsystem-basel-rss-feed",
-          "source": "http://www.parkleitsystem-basel.ch/status.php",
+          "url": "http://www.parkleitsystem-basel.ch/status.php",
+          "source": "http://www.parkleitsystem-basel.ch/rss_feed.php",
 	  "active_support": true,
           "attribution":{
             "contributor":"Immobilien Basel-Stadt",
@@ -30,11 +30,7 @@
     "properties": {
       "name": "Parkhaus Bad. Bahnhof",
       "total": 300, 
-      "totalByWeekday": {
-        "Monday": 300, 
-        "Tuesday": 300, 
-        "Wednesday": 300, 
-        "Friday": 300, 
+      "total_by_weekday": {
         "Saturday": 750,
         "Sunday": 750
       }
@@ -78,11 +74,7 @@
     "properties": {
       "name": "Parkhaus Claramatte",
       "total": 100,
-      "totalByWeekday": {
-        "Monday": 100, 
-        "Tuesday": 100, 
-        "Wednesday": 100, 
-        "Friday": 100, 
+      "total_by_weekday": {
         "Saturday": 170,
         "Sunday": 170
       }

--- a/park_api/cities/Basel.geojson
+++ b/park_api/cities/Basel.geojson
@@ -29,7 +29,15 @@
     },
     "properties": {
       "name": "Parkhaus Bad. Bahnhof",
-      "total": 300 
+      "total": 300, 
+      "totalByWeekday": {
+        "Monday": 300, 
+        "Tuesday": 300, 
+        "Wednesday": 300, 
+        "Friday": 300, 
+        "Saturday": 750,
+        "Sunday": 750
+      }
     }
   }, {
     "type": "Feature",
@@ -69,7 +77,15 @@
     },
     "properties": {
       "name": "Parkhaus Claramatte",
-      "total": 100
+      "total": 100,
+      "totalByWeekday": {
+        "Monday": 100, 
+        "Tuesday": 100, 
+        "Wednesday": 100, 
+        "Friday": 100, 
+        "Saturday": 170,
+        "Sunday": 170
+      }
     }
   }, {
     "type": "Feature",

--- a/park_api/cities/Basel.geojson
+++ b/park_api/cities/Basel.geojson
@@ -190,7 +190,7 @@
       "coordinates": [7.5884556, 47.5458851]
     },
     "properties": {
-      "name": "Parkhaus Bahnhof S&uuml;d",
+      "name": "Parkhaus Bahnhof Süd",
       "address": "Güterstrasse 115",
       "total": 100
     }

--- a/park_api/cities/Basel.py
+++ b/park_api/cities/Basel.py
@@ -2,9 +2,6 @@ import feedparser
 from park_api.geodata import GeoData
 from park_api.util import utc_now
 
-
-# Falls das hier jemals einer von den Menschen
-# hinter OpenDataZürich lesen sollte: Ihr seid so toll <3
 geodata = GeoData(__file__)
 
 
@@ -45,7 +42,7 @@ def parse_html(xml_data):
 
 
 def parse_summary(summary):
-    """Parse a string from the format 'open /   41' into both its params"""
+    """Parse a string from the format 'Anzahl freie Parkpl&auml;tze: 179' into both its params"""
     summary = summary.split(":")
 
     summary[0] = summary[0].strip()
@@ -61,8 +58,7 @@ def parse_summary(summary):
 
 def parse_title(title):
     """
-    Parse a string from the format 'Parkgarage am Central / Seilergraben'
-    into both its params
+    Parse a string from the format 'Parkhaus Bad. Bahnhof'
     """
     types = ["Parkhaus", "Parkplatz"]
 

--- a/park_api/cities/Basel.py
+++ b/park_api/cities/Basel.py
@@ -1,0 +1,76 @@
+import feedparser
+from park_api.geodata import GeoData
+from park_api.util import utc_now
+
+
+# Falls das hier jemals einer von den Menschen
+# hinter OpenDataZürich lesen sollte: Ihr seid so toll <3
+geodata = GeoData(__file__)
+
+
+def parse_html(xml_data):
+    feed = feedparser.parse(xml_data)
+
+    try:
+        last_updated = feed["entries"][0]["updated"]
+    except KeyError:
+        last_updated = utc_now()
+
+    data = {
+        "lots": [],
+        # remove trailing timezone for consensistency
+        "last_updated": last_updated.replace("Z", "")
+    }
+
+    for entry in feed["entries"]:
+        summary = parse_summary(entry["summary"])
+        title_elements = parse_title(entry["title"])
+
+        lot_identifier = (title_elements[2] + " " + title_elements[0]).strip()
+        lot = geodata.lot(lot_identifier)
+
+        data["lots"].append({
+            "name": title_elements[0],
+            "address": title_elements[1],
+            "id": lot.id,
+            "state": summary[0],
+            "free": summary[1],
+            "total": lot.total,
+            "coords": lot.coords,
+            "forecast": False,
+            "lot_type": title_elements[2]
+        })
+
+    return data
+
+
+def parse_summary(summary):
+    """Parse a string from the format 'open /   41' into both its params"""
+    summary = summary.split(":")
+
+    summary[0] = summary[0].strip()
+    if "?" in summary[0]:
+        summary[0] = "nodata"
+
+    try:
+        summary[1] = int(summary[1])
+    except ValueError:
+        summary[1] = 0
+    return summary
+
+
+def parse_title(title):
+    """
+    Parse a string from the format 'Parkgarage am Central / Seilergraben'
+    into both its params
+    """
+    types = ["Parkhaus", "Parkplatz"]
+
+    name = title
+    address = ''
+    type = ""
+    if name.split(" ")[0] in types:
+        type = name.split(" ")[0]
+        name = " ".join(name.split(" ")[1:])
+
+    return name, address, type

--- a/park_api/cities/Basel.py
+++ b/park_api/cities/Basel.py
@@ -1,4 +1,5 @@
 import feedparser
+from datetime import datetime
 from park_api.geodata import GeoData
 from park_api.util import utc_now
 
@@ -10,13 +11,15 @@ def parse_html(xml_data):
 
     try:
         last_updated = feed["entries"][0]["updated"]
+        last_updated = datetime.strptime(last_updated[5:25], "%d %b %Y %H:%M:%S").isoformat()
     except KeyError:
         last_updated = utc_now()
 
+
+
     data = {
         "lots": [],
-        # remove trailing timezone for consensistency
-        "last_updated": last_updated.replace("Z", "")
+        "last_updated": last_updated
     }
 
     for entry in feed["entries"]:
@@ -30,14 +33,13 @@ def parse_html(xml_data):
             "name": title_elements[0],
             "address": title_elements[1],
             "id": lot.id,
-            "state": summary[0],
+            "state": "open",
             "free": summary[1],
             "total": lot.total,
             "coords": lot.coords,
             "forecast": False,
             "lot_type": title_elements[2]
         })
-
     return data
 
 

--- a/park_api/cities/Basel.py
+++ b/park_api/cities/Basel.py
@@ -1,4 +1,5 @@
 import feedparser
+import html
 from datetime import datetime
 from park_api.geodata import GeoData
 from park_api.util import utc_now
@@ -26,13 +27,13 @@ def parse_html(xml_data):
         summary = parse_summary(entry["summary"])
         title_elements = parse_title(entry["title"])
 
-        lot_identifier = (title_elements[2] + " " + title_elements[0]).strip()
+        lot_identifier = html.unescape((title_elements[2] + " " + title_elements[0]).strip())
         lot = geodata.lot(lot_identifier)
 
         data["lots"].append({
-            "name": title_elements[0],
-            "address": title_elements[1],
-            "id": lot.id,
+            "name": html.unescape(title_elements[0]),
+            "address": lot.address,
+            "id": html.unescape(lot.id),
             "state": "open",
             "free": summary[1],
             "total": lot.total,

--- a/park_api/geodata.py
+++ b/park_api/geodata.py
@@ -1,4 +1,6 @@
 import os
+from datetime import date
+import calendar
 
 import json
 from collections import namedtuple
@@ -106,6 +108,10 @@ class GeoData:
     def _lot_from_props(self, name, lng, lat, props):
         address = props.get("address", None)
         total = props.get("total", 0)
+        if "total_by_weekday" in props.keys():
+            weekday = calendar.day_name[date.today().weekday()]
+            if weekday in props.get("total_by_weekday"):
+                total = props.get("total_by_weekday").get(weekday)
         _type = props.get("type", None)
         _aux = props.get("aux", None)
         _id = generate_id(self.city_name + name)

--- a/tests/fixtures/basel.xml
+++ b/tests/fixtures/basel.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="windows-1252"?>
+<!-- generator="FeedCreator 1.7.2-ppt (info@mypapit.net)" -->
+<rss version="2.0"><script/><script/>
+    <channel>
+        <title>Permanentes Parkleitsystem Basel</title>
+        <description>Ein Parkleitsystem ist ein Informationssystem welches die Aufgabe hat, Parkmoeglichkeiten in einer Stadt anzuzeigen und die Autofahrer zielgerecht dorthin zu fuehren.</description>
+        <link>http://www.parkleitsystem-basel.ch/status.php</link>
+        <lastBuildDate>Thu, 07 Feb 2019 12:35:17 +0100</lastBuildDate>
+        <generator>FeedCreator 1.7.2-ppt (info@mypapit.net)</generator>
+        <item>
+            <title>Parkhaus Bad. Bahnhof</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/badbahnhof.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 267</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Messe</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/messe.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 177</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Europe</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/europe.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 50</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Rebgasse</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/rebgasse.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 69</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Claramatte</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/claramatte.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 64</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Clarahuus</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/clarahuus.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 22</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Elisabethen</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/elisabethen.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 277</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Steinen</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/steinen.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 125</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus City-USB</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/city-usb.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 214</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Storchen</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/storchen.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 13</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Post Basel</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/postbasel.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 0</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Centralbahnparking</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/centralbahnparking.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 184</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Aeschen</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/aeschen.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 50</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Anfos</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/anfos.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 0</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+        <item>
+            <title>Parkhaus Bahnhof S&amp;uuml;d</title>
+            <link>http://www.parkleitsystem-basel.ch/parkhaus/bahnhofsued.php</link>
+            <description>Anzahl freie Parkpl&amp;auml;tze: 5</description>
+            <comments>Stand: 07.02.2019 12:35:00</comments>
+            <pubDate>Thu, 07 Feb 2019 12:35:00 +0100</pubDate>
+        </item>
+    </channel>
+</rss>

--- a/tests/test_cities.py
+++ b/tests/test_cities.py
@@ -109,6 +109,10 @@ class CityTestCase(unittest.TestCase):
         city_name = "Aalborg"
         self.sanity_check(city_name, scrape_city(city_name, ".json"))
 
+    def test_basel(self):
+        city_name = "Basel"
+        self.sanity_check(city_name, scrape_city(city_name, ".xml"))
+
     def test_sample(self):
         city_name = "Sample_City"
         self.sanity_check(city_name, scrape_city(city_name))


### PR DESCRIPTION
See discussion in #35. 

We have added the total number of lots that are different during wekeends in the geojson file as follows: https://github.com/offenesdresden/ParkAPI/blob/1ce2270962d7c6b919211fac54eb72ef338b7d57/park_api/cities/Basel.geojson#L34-L36

To parse this, we have amended geojson.py to override the total number of lots with the number stated for today's weekday, see: 
https://github.com/offenesdresden/ParkAPI/blob/1ce2270962d7c6b919211fac54eb72ef338b7d57/park_api/geodata.py#L111-L114