### PR TITLE
Update city_schema.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ Also please note that this is not valid JSON. Just an example for how the output
       },
       "name": "Altmarkt",
       "total": 400,
-      "free": 235,
-      "state": "open|closed|nodata",
+      "free": 235, // >= 0, optional, can be missing, if no live data available
+      "state": "open|closed|nodata|unknown",
       "id": "lot_id",
       "forecast": true|false,
       "region": "Region X", // optional
       "address": "Musterstraße 5", // optional
-      "lot_type": "Parkhaus" // optional
+      "lot_type": "Parkhaus", // optional,
+      "opening_hours": "24/7", // optional, in OSM opening_hours syntax
+      "fee_hours": "Mo-Fr 07:00-22:00; PH off", // optional, in OSM opening_hours syntax
+      "url": "http://examplecity.com/parken/Altmarkt" // optional
     },
     ...
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 Flask
 requests
-feedparser==5.2.1
+feedparser
 pytz
 psycopg2
 yoyo-migrations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 Flask
 requests
-feedparser
+feedparser==5.2.1
 pytz
 psycopg2
 yoyo-migrations

--- a/schema/city_schema.json
+++ b/schema/city_schema.json
@@ -1,67 +1,128 @@
 {
-	"$schema":"http://jkliemann.de/parkendd/media/city_schema.json",
-	"title":"ParkenDD JSON API",
-	"description":"JSON required by ParkenDD app to show parking lots",
-	"type":"array",
-	"items":{
-		"type":"object",
-		"properties":{
-			"name":{
-				"description":"Name of parking lot category",
-				"type":"string"
-			},
-			"lots":{
-				"description":"Parking lots in this category",
-				"type":"array",
-				"items":{
-					"type":"object",
-					"properties":{
-						"name":{
-							"description":"Name of parking lot",
-							"type":"string"
-						},
-						"count":{
-							"description":"Count of available parking lots",
-							"type":"integer"
-						},
-						"free":{
-							"description":"Count of free parking lots",
-							"type":"integer"
-						},
-						"state":{
-							"description":"State of the parking lot",
-							"type":"string",
-							"enum":["nodata","closed","many","few","full"]
-						},
-						"lat":{
-							"description":"latitude of the parking lot",
-							"type":"string"
-						},
-						"lon":{
-							"description":"longitude of the parking lot",
-							"type":"string"
-						},
-						"forecast":{
-							"description":"shows if forecast is available for this spot",
-							"type":"boolean"
-						},
-						"url":{
-							"description":"A URL of a web resource where more information can be viewed",
-							"type":"string"
-						},
-						"opening_hours":{
-							"description":"Opening hours of this lot in OpenStreetMap format (https://wiki.openstreetmap.org/wiki/Key:opening_hours)",
-							"type":"string"
-						},
-						"fee_hours":{
-							"description":"Hours during which usage of this lot incurrs fees in OpenStreetMap format (https://wiki.openstreetmap.org/wiki/Key:opening_hours). It is implied that outside those hours usage is free.",
-							"type":"string"
-						}
-					},
-					"required":["name", "count", "state", "forecast"]
-				}
-			}
-		},
-			"required":["name", "lots"]
-	}
+  "$schema": "http://jkliemann.de/parkendd/media/city_schema.json",
+  "title": "ParkenDD JSON API",
+  "description": "JSON required by ParkenDD app to show parking lots",
+  "type": "object",
+  "properties": {
+    "last_downloaded": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "last_updated": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "lots": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "coords": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "lat": {
+                    "type": "number",
+                    "minimum": -90,
+                    "maximum": 90
+                  },
+                  "lng": {
+                    "type": "number",
+                    "minimum": -180,
+                    "maximum": 180
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "forecast": {
+            "type": "boolean"
+          },
+          "free": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "id": {
+            "type": "string"
+          },
+          "lot_type": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "region": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "state": {
+            "enum": [
+              "open",
+              "nodata",
+              "closed",
+              "many",
+              "few",
+              "full"
+            ]
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "opening_hours": {
+            "type": "string"
+          },
+          "fee_hours": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "forecast",
+          "free",
+          "id",
+          "name",
+          "state",
+          "total"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "last_downloaded",
+    "last_updated",
+    "lots"
+  ],
+  "additionalProperties": false
 }

--- a/schema/city_schema.json
+++ b/schema/city_schema.json
@@ -87,9 +87,7 @@
               "open",
               "nodata",
               "closed",
-              "many",
-              "few",
-              "full"
+              "unknown"
             ]
           },
           "total": {
@@ -109,7 +107,6 @@
         },
         "required": [
           "forecast",
-          "free",
           "id",
           "name",
           "state",

--- a/schema/city_schema.json
+++ b/schema/city_schema.json
@@ -112,7 +112,7 @@
           "state",
           "total"
         ],
-        "additionalProperties": false
+        "additionalProperties": true
       }
     }
   },
@@ -121,5 +121,5 @@
     "last_updated",
     "lots"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }


### PR DESCRIPTION
This PR fixes #219 by updating city_schema.json.

Note that nevertheless, some current city responses are not valid according to this schema.

Especially Aarhus and Koeln currently report states as "unknown", which IMHO should be reported as "nodata". Further, Koeln reports free=-1 for some parkings. As this seems to represent an unknown value. If true, it should rather be left out, as it is not mandatory.

Note further, that this schema uses some anyOf-type-validations, to allow currently used practice to specify null values for values required by the former schema, but apparently unknown. IMHO null should not be allowed for required properties, but that would result in rework for some data providers.

Finally, this schema s rather strict by not allowing additionalProperties. This kind of blocks experimental features, but uncovers properties not yet specified in the schema. Probably, additionalProperties should better be set to true. 