### PR TITLE
Bump python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: python
 python:
-  - "3.5"
   - "3.7"
+  - "3.8"
+  - "3.9"
   - "nightly"
 addons:
   postgresql: "9.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4-alpine
+FROM python:3.7-alpine
 LABEL maintainer="Max Schorradt <schorradt@publicplan.de>"
 
 ENV port=5000

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Also please note that this is not valid JSON. Just an example for how the output
 
 ### Setup your own server
 
- - First you will need python (at least 3.3), pip and virtualenv installed. In the following it is assumed that python is python3 and virtualenv is virtualenv3. If this is not the case for your distribution please use the correct executables. If virtualenv3 is not available, use virtualenv -p /usr/bin/python3.
+ - First you will need python (at least 3.7), pip and virtualenv installed. In the following it is assumed that python is python3 and virtualenv is virtualenv3. If this is not the case for your distribution please use the correct executables. If virtualenv3 is not available, use virtualenv -p /usr/bin/python3.
  
  - Install the following packages: postgresql libpq-dev
 

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,9 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     keywords='webapp parkinglots scraping',


### PR DESCRIPTION
This PR fixes #222 by removing python versions prior to 3.7 from .travis.yml and setup.py as well as bumping the Dockerfile base image to 3.7-alpine.