### PR TITLE
Update issues with missing Freiburg parking lots

### DIFF
--- a/park_api/cities/Freiburg.py
+++ b/park_api/cities/Freiburg.py
@@ -25,6 +25,10 @@ def parse_html(source_json):
         lot_name = feature['properties']['park_name']
         lot_free = int(feature['properties']['obs_free'])
         lot_total = int(feature['properties']['obs_max'])
+        lot_coords = {"lat": feature['geometry']['coordinates'][1],
+                      "lng": feature['geometry']['coordinates'][0]
+                     }
+        lot_address = feature['properties']['park_id']
 
         obs_ts = feature['properties']['obs_ts'].split('.')[0]
         if last_updated < obs_ts:
@@ -41,11 +45,11 @@ def parse_html(source_json):
 
         lot = geodata.lot(lot_name)
         data["lots"].append({
-            "name": lot.name,
+            "name": lot_name,
             "free": lot_free,
             "total": lot_total,
-            "address": lot.address,
-            "coords": lot.coords,
+            "address": lot_address,
+            "coords": lot_coords,
             "state": state,
             "lot_type": lot.type,
             "id": lot.id,


### PR DESCRIPTION
This is an update to the Freiburg.py, to amend the missing parking lots from the current data published on the [ParkAPI Freiburg](https://api.parkendd.de/Freiburg) in comparison with the [Geo-Portal of city of Freiburg](http://stadtplan.freiburg.de/wfs/gdm_pls/gdm_plslive?request=getfeature&service=wfs&version=1.1.0&typename=pls&outputformat=geojson&srsname=epsg:4326)